### PR TITLE
Added help message for command line options.

### DIFF
--- a/cmd/git-aico/main.go
+++ b/cmd/git-aico/main.go
@@ -103,6 +103,13 @@ func parseOpenAIResponse(response string, verbose bool) ([]string, error) {
 	return messages, nil
 }
 
+func printHelp() {
+	fmt.Println("Usage: git-aico [options]")
+	fmt.Println("Options:")
+	fmt.Println("  -h        Show this help message")
+	fmt.Println("  -v        Enable verbose output")
+}
+
 func main() {
 	var cfg Config
 	err := envconfig.Process("", &cfg)
@@ -112,8 +119,13 @@ func main() {
 	}
 
 	verbose = false // Default verbose to false
-	if len(os.Args) > 1 && os.Args[1] == "-v" {
-		verbose = true
+	for _, arg := range os.Args[1:] {
+		if arg == "-v" {
+			verbose = true
+		} else if arg == "-h" {
+			printHelp()
+			return
+		}
 	}
 
 	// Execute git diff and get the output


### PR DESCRIPTION
## Description

* This pull request adds a help option to the `git-aico` command, providing users with usage information and available options.

### Changes
1. Added `printHelp` function:
   - This function prints the usage information and available options for the `git-aico` command.

2. Updated `main` function:
   - Added a loop to check for `-h` and `-v` options in the command-line arguments.
   - If `-h` is provided, the `printHelp` function is called and the program exits.
   - If `-v` is provided, verbose mode is enabled.

### Testing
- Verified that running `git-aico -h` displays the help message.
- Verified that running `git-aico -v` enables verbose mode.
- Verified that running `git-aico` without options works as expected.