### PR TITLE
Add Japanese Output Option to Commit Message Generator

### DIFF
--- a/cmd/git-aico/main.go
+++ b/cmd/git-aico/main.go
@@ -118,13 +118,16 @@ func main() {
 		return
 	}
 
-	verbose = false // Default verbose to false
+	verbose := false // Default verbose to false
+	japaneseOutput := false // Default Japanese output to false
 	for _, arg := range os.Args[1:] {
 		if arg == "-v" {
 			verbose = true
 		} else if arg == "-h" {
 			printHelp()
 			return
+		} else if arg == "-j" {
+			japaneseOutput = true
 		}
 	}
 
@@ -149,7 +152,7 @@ func main() {
 	}
 
 	// Create a question for the OpenAI API based on the diff output
-	question := aico.CreateOpenAIQuestion(diffOutput, cfg.NumCandidates)
+	question := aico.CreateOpenAIQuestion(diffOutput, cfg.NumCandidates, japaneseOutput)
 	// Ask OpenAI for commit message suggestions
 	response, err := aico.AskOpenAI(openAIURL, cfg.OpenAIKey, cfg.OpenAIModel, cfg.OpenAITemperature, cfg.OpenAIMaxTokens, question, verbose)
 	if err != nil {

--- a/prompt.go
+++ b/prompt.go
@@ -3,7 +3,7 @@ package aico
 import "fmt"
 
 // CreateOpenAIQuestion formats a question for the OpenAI API based on the git diff output.
-func CreateOpenAIQuestion(diffOutput string, numCandidates int) string {
+func CreateOpenAIQuestion(diffOutput string, numCandidates int, japaneseOutput bool) string {
 	prompt := `
 Please generate %d appropriate commit message candidates based on the context.
 (Do NOT number at the beginning of the line)
@@ -51,5 +51,54 @@ Output Format:
 ---
 
 %s`
+	if japaneseOutput {
+		prompt = `
+以下の内容に基づいて、%d個の適切なコミットメッセージ候補を生成してください。
+（行の先頭に番号を付けないでください）
+
+以下は、さまざまなシナリオのコミットメッセージのサンプルです。
+
+---
+
+# 新機能の追加
+ホームページに検索機能を追加
+
+# バグ修正
+ログイン時にアプリがクラッシュするバグを修正
+
+# コードのリファクタリング
+可読性のためにデータ解析関数をリファクタリング
+
+# テストの追加
+ユーザー登録の単体テストを追加
+
+# ドキュメントの更新
+新しいインストール手順でREADMEを更新
+
+# パフォーマンスの向上
+製品画像の読み込み速度を向上
+
+# 依存関係の更新
+lodashをバージョン4.17.21に更新
+
+# 不要なコードの削除
+廃止されたAPIエンドポイントを削除
+
+# UI/UXの改善
+モバイルビューのユーザーインターフェースを改善
+
+# コードコメントの追加または変更
+ルーティングモジュールのコメントを更新
+---
+
+出力形式:
+- Gitの差分を処理するためのdiffローダーモジュールを追加
+- diffloader.tsでファイルとGitからの差分の読み込みを実装
+- Gitの差分を処理し、分割するためのdiffloader.tsを作成
+
+---
+
+%s`
+	}
 	return fmt.Sprintf(prompt, numCandidates, diffOutput)
 }


### PR DESCRIPTION
## Description

* This pull request introduces a new feature that allows the commit message generator to output messages in Japanese. This is controlled via a new command-line flag `-j`.

### Changes
1. Change:
   - Updated `main.go` to include a new flag `-j` for Japanese output.
   - Modified the verbose flag initialization to use `:=` for consistency.

2. Change:
   - Updated the `CreateOpenAIQuestion` function in `prompt.go` to accept an additional `japaneseOutput` parameter.
   - Added logic to format the prompt in Japanese if the `japaneseOutput` flag is set.

3. Change:
   - Enhanced the prompt template in `prompt.go` to include Japanese examples and instructions when the `japaneseOutput` flag is true.

### Testing
- Verified that the application correctly handles the new `-j` flag and generates commit messages in Japanese.
- Ensured that the existing functionality remains unaffected when the `-j` flag is not used.
- Tested various combinations of flags to confirm that the application behaves as expected.