### PR TITLE
Add flag package for command-line options parsing and improve help message

### DIFF
--- a/cmd/git-aico/main.go
+++ b/cmd/git-aico/main.go
@@ -110,10 +110,18 @@ func parseOpenAIResponse(response string, verbose bool) ([]string, error) {
 func printHelp() {
 	helpText := `
 Usage: git-aico [options]
+
 Options:
   -h        Show this help message
   -v        Enable verbose output
   -j        Output commit message suggestions in Japanese
+
+Environment Variables:
+  OPENAI_API_KEY       Your OpenAI API key (required)
+  NUM_CANDIDATES       Number of commit message candidates to generate (default: 3)
+  OPENAI_MODEL         OpenAI model to use (default: gpt-4o)
+  OPENAI_TEMPERATURE   Sampling temperature (default: 0.1)
+  OPENAI_MAX_TOKENS    Maximum number of tokens in the response (default: 450)
 `
 	fmt.Println(helpText)
 }

--- a/cmd/git-aico/main.go
+++ b/cmd/git-aico/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"flag"
 	"fmt"
 	"os"
 	"strconv"
@@ -23,7 +24,10 @@ type Config struct {
 	OpenAIMaxTokens   int     `envconfig:"OPENAI_MAX_TOKENS" default:"450"`
 }
 
-var verbose bool // Global flag to control verbose output
+var (
+	verbose        bool // Global flag to control verbose output
+	japaneseOutput bool // Global flag to control Japanese output
+)
 
 // selectCommitMessage prompts the user to select a commit message from a list of suggestions.
 func selectCommitMessage(suggestions []string) (string, error) {
@@ -122,17 +126,15 @@ func main() {
 		return
 	}
 
-	verbose := false        // Default verbose to false
-	japaneseOutput := false // Default Japanese output to false
-	for _, arg := range os.Args[1:] {
-		if arg == "-v" {
-			verbose = true
-		} else if arg == "-h" {
-			printHelp()
-			return
-		} else if arg == "-j" {
-			japaneseOutput = true
-		}
+	flag.BoolVar(&verbose, "v", false, "Enable verbose output")
+	flag.BoolVar(&japaneseOutput, "j", false, "Output commit message suggestions in Japanese")
+	showHelp := flag.Bool("h", false, "Show this help message")
+
+	flag.Parse()
+
+	if *showHelp {
+		printHelp()
+		return
 	}
 
 	// Execute git diff and get the output

--- a/cmd/git-aico/main.go
+++ b/cmd/git-aico/main.go
@@ -104,11 +104,14 @@ func parseOpenAIResponse(response string, verbose bool) ([]string, error) {
 }
 
 func printHelp() {
-	fmt.Println("Usage: git-aico [options]")
-	fmt.Println("Options:")
-	fmt.Println("  -h        Show this help message")
-	fmt.Println("  -v        Enable verbose output")
-	fmt.Println("  -j        Output commit message suggestions in Japanese")
+	helpText := `
+Usage: git-aico [options]
+Options:
+  -h        Show this help message
+  -v        Enable verbose output
+  -j        Output commit message suggestions in Japanese
+`
+	fmt.Println(helpText)
 }
 
 func main() {
@@ -119,7 +122,7 @@ func main() {
 		return
 	}
 
-	verbose := false // Default verbose to false
+	verbose := false        // Default verbose to false
 	japaneseOutput := false // Default Japanese output to false
 	for _, arg := range os.Args[1:] {
 		if arg == "-v" {


### PR DESCRIPTION
---
## Description

This pull request introduces several enhancements and refactors to the `git-aico` command-line tool. The primary changes include the addition of a new flag for Japanese output, refactoring of the help message, and the use of the `flag` package for command-line argument parsing.

### Changes
1. Added a new flag for Japanese output:
   - Introduced a global flag `japaneseOutput` to control the output of commit message suggestions in Japanese.
   - Updated the `printHelp` function to include the new flag in the usage instructions.

2. Refactored the help message:
   - Consolidated the help message into a single string variable `helpText` for better readability and maintainability.
   - Included environment variable descriptions in the help message.

3. Switched to using the `flag` package for argument parsing:
   - Replaced manual argument parsing with the `flag` package for better handling and scalability.
   - Defined flags for verbose output, Japanese output, and help message display.

### Testing
- Verified that the help message displays correctly with the new format and includes all relevant information.
- Tested the `-v` flag to ensure verbose output is enabled when specified.
- Tested the `-j` flag to ensure commit message suggestions are output in Japanese when specified.
- Ensured that the tool exits gracefully when the help message is displayed.

---