### PR TITLE
Add GitHub Actions workflow for release on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,16 @@
+name: release
+on:
+  push:
+    tags:
+      - "v*"
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: cli/gh-extension-precompile@v1
+        with:
+          go_version: "1.21"


### PR DESCRIPTION
---
## Description

* This pull request introduces a new GitHub Actions workflow for automating the release process. The workflow is triggered by pushing tags that match the pattern "v*".

### Changes
1. Added a new GitHub Actions workflow file:
   - Created `.github/workflows/release.yml` to define the release process.
   - The workflow is triggered on tag pushes that follow the "v*" pattern.
   - Configured permissions to allow writing to contents.

2. Defined the release job:
   - The job runs on the latest Ubuntu environment.
   - Utilizes the `actions/checkout@v3` action to check out the repository code.
   - Uses the `cli/gh-extension-precompile@v1` action with Go version 1.21 for precompilation tasks.

### Testing
- Verified the workflow syntax and ensured it triggers correctly on tag pushes.
- Tested the release job on a test branch to confirm successful execution of steps and actions.

---